### PR TITLE
[feat] 책 상세정보 페이지 '목표추가' 기능 구현

### DIFF
--- a/src/main/java/com/bunge/memo/domain/ReadState.java
+++ b/src/main/java/com/bunge/memo/domain/ReadState.java
@@ -1,0 +1,32 @@
+package com.bunge.memo.domain;
+
+public class ReadState {
+
+    private String isbn13;
+    private String id;
+    private String state;
+
+    public String getIsbn13() {
+        return isbn13;
+    }
+
+    public void setIsbn13(String isbn13) {
+        this.isbn13 = isbn13;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getState() {
+        return state;
+    }
+
+    public void setState(String state) {
+        this.state = state;
+    }
+}

--- a/src/main/java/com/bunge/memo/mapper/ReadStateMapper.java
+++ b/src/main/java/com/bunge/memo/mapper/ReadStateMapper.java
@@ -1,0 +1,11 @@
+package com.bunge.memo.mapper;
+
+import com.bunge.memo.domain.ReadState;
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface ReadStateMapper {
+
+    //"목표" 추가
+    public void addGoal(ReadState readState);
+}

--- a/src/main/java/com/bunge/memo/service/ReadStateService.java
+++ b/src/main/java/com/bunge/memo/service/ReadStateService.java
@@ -1,0 +1,9 @@
+package com.bunge.memo.service;
+
+import com.bunge.memo.domain.ReadState;
+
+public interface ReadStateService {
+
+    //"목표" 추가
+    public void addGoal(ReadState readState);
+}

--- a/src/main/java/com/bunge/memo/service/ReadStateServiceImpl.java
+++ b/src/main/java/com/bunge/memo/service/ReadStateServiceImpl.java
@@ -1,0 +1,20 @@
+package com.bunge.memo.service;
+
+import com.bunge.memo.domain.ReadState;
+import com.bunge.memo.mapper.ReadStateMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class ReadStateServiceImpl implements ReadStateService {
+
+    private ReadStateMapper readStateMapper;
+
+    @Autowired
+    public ReadStateServiceImpl(ReadStateMapper readStateMapper) {this.readStateMapper = readStateMapper;}
+
+    @Override
+    public void addGoal(ReadState readState) {
+        readStateMapper.addGoal(readState);
+    }
+}

--- a/src/main/resources/mapper/ReadState.xml
+++ b/src/main/resources/mapper/ReadState.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.bunge.memo.mapper.ReadStateMapper">
+
+    <insert id="addGoal">
+        insert into readstate
+        (isbn13, id, state)
+        values
+        (#{isbn13}, #{id}, #{state})
+    </insert>
+
+</mapper>

--- a/src/main/resources/static/js/bookdetail.js
+++ b/src/main/resources/static/js/bookdetail.js
@@ -1,0 +1,77 @@
+let token = $("meta[name='_csrf']").attr("content");
+let header = $("meta[name='_csrf_header']").attr("content");
+
+$(function() {
+
+    //console.log(window.location.search);
+    const url = new URL(window.location.href);
+    const urlParams = url.searchParams;
+    const isbn13 = urlParams.get("isbn13")
+    const loginId = $("#loginId").text();
+    //console.log("loginId : " + loginId);
+    //console.log(isbn13);
+
+    //상품 조회 API (상품 리스트 API와 다름)
+    $.ajax({
+        url: "http://www.aladin.co.kr/ttb/api/ItemLookUp.aspx",
+        data: {
+            "ttbkey" : "ttbyyy24941308001",
+            "itemIdType" : "ISBN13",
+            "ItemId" : isbn13,
+            "output" : "JS",
+            "Version" : "20131101",
+        },
+        dataType : "json",
+        cache : false,
+        success : function (rdata) {
+            //console.log(rdata)
+            //console.log(rdata.item[0].subInfo.itemPage)
+            let itemPage = rdata.item[0].subInfo.itemPage
+            $("#itemPage").text(itemPage + " page")
+        }
+
+    })
+
+    $("#addGoal").click(function() {
+
+        const goalData = {
+            isbn13 : isbn13,
+            id : loginId,
+            state : "목표"
+        };
+
+        let answer = confirm("목표로 추가하시겠습니까?")
+
+        if (answer) {
+            $.ajax({
+                url : "readstate",
+                method : "POST",
+                contentType: "application/json; charset=utf-8",
+                data : JSON.stringify(goalData),
+                dataType : "json",
+                cache : false,
+                beforeSend : function (xhr) {
+                    if (header && token) {
+                        xhr.setRequestHeader(header, token);
+                    }
+                },
+                success : function(response) {
+
+                    //console.log("response : " + response.message)
+
+                    if (response.message == "success") {
+                        alert("해당 도서가 '목표'로 추가되었습니다.");
+                    } else {
+                        alert("'목표' 추가에 실패하였습니다.");
+                    }
+                },
+                error : function(error) {
+                    alert("이미 목표 도서에 추가되어 있습니다.");
+                    console.error("목표 추가 중 오류 발생:", error);
+                }
+            }) //ajax end
+        } //if (answer) end
+
+    }) // $("#addGoal").click
+
+})

--- a/src/main/resources/templates/memo/book_detail.html
+++ b/src/main/resources/templates/memo/book_detail.html
@@ -1,0 +1,133 @@
+<!DOCTYPE html>
+<html th:replace="~{layout/layoutFile :: layout (~{::title}, ~{::links}, ~{::section})}"
+      xmlns:th="http://www.thymeleaf.org">
+<head>
+    <title>책 상세정보 페이지</title>
+    <links>
+        <script th:src="@{/js/bookdetail.js}"></script>
+    </links>
+</head>
+<body>
+
+<div id="root" class="root mn--max tm--expanded-hd">
+    <section id="content" class="content">
+        <div class="content__header content__boxed">
+            <div class="content__wrap">
+
+                <!-- Breadcrumb -->
+                <nav aria-label="breadcrumb">
+                    <ol class="breadcrumb">
+                        <li class="breadcrumb-item"><a th:href="@{main}">Home</a></li>
+                        <li class="breadcrumb-item"><a th:href="@{mine}">기록 · 리뷰</a></li>
+                        <li class="breadcrumb-item"><a th:href="@{searcgnaub}">책 검색</a></li>
+                        <li class="breadcrumb-item active" aria-current="page">책 상세정보</li>
+                    </ol>
+                </nav>
+                <!-- END : Breadcrumb -->
+
+                <h1 class="page-title mb-2 mt-2">책 상세정보</h1>
+                <p class="lead">
+                    등록된 책들의 상세정보를 조회할 수 있습니다
+                </p>
+
+            </div>
+
+            <div class="content__boxed">
+                <div class="content__wrap">
+
+                    <div class="row mb-3">
+                        <div class="col-md-6">
+
+                            <div class="tab-base">
+
+                                <!-- Nav tabs -->
+                                <ul class="nav nav-tabs" role="tablist">
+                                    <li class="nav-item active" role="presentation">
+                                        <button class="nav-link active" data-bs-toggle="tab"
+                                                data-bs-target="#_dm-tabsBookDetail" type="button" role="tab"
+                                                aria-controls="bookDetail" aria-selected="true">상세정보
+                                        </button>
+                                    </li>
+                                </ul>
+
+                                <!-- Tabs content -->
+                                <div class="tab-content" style="color:black">
+                                    <div id="_dm-tabsBookDetail" class="tab-pane fade active show" role="tabpanel" aria-labelledby="bookDetail-tab">
+                                        <!-- Card blog with image -->
+                                        <div class="row">
+                                            <div class="col-md-4">
+                                                <img th:src="${book.cover}" alt="..." loading="lazy">
+                                            </div>
+                                            <div class="col-md-8">
+                                                <div class="row mb-3 border-bottom">
+                                                    <div class="col-md-2 text-center align-content-center text-bg-success">
+                                                        제목
+                                                    </div>
+                                                    <div class="col-md-10" th:text="${book.title.length() > 40 ? #strings.substring(book.title, 0, 40) + '...' : book.title}"></div>
+                                                </div>
+                                                <div class="row mb-3 border-bottom">
+                                                    <div class="col-md-2 text-center align-content-center text-bg-success">
+                                                        저자
+                                                    </div>
+                                                    <div class="col-md-10">
+                                                        [[${book.author}]]
+                                                    </div>
+                                                </div>
+                                                <div class="row mb-3 border-bottom">
+                                                    <div class="col-md-2 text-center align-content-center text-bg-success">
+                                                        별점
+                                                    </div>
+                                                    <div class="col-md-10">
+                                                        [[${book.score}]]점
+                                                    </div>
+                                                </div>
+                                                <div class="row mb-3 border-bottom">
+                                                    <div class="col-md-2 text-center align-content-center text-bg-success">
+                                                        페이지
+                                                    </div>
+                                                    <div class="col-md-10" id="itemPage">
+                                                    </div>
+                                                </div>
+                                                <div class="row mb-3 border-bottom">
+                                                    <div class="col-md-2 text-center align-content-center text-bg-success">
+                                                        도전 중
+                                                    </div>
+                                                    <div class="col-md-2" id="challengeCount">
+                                                        5명
+                                                    </div>
+                                                </div>
+                                                <div class="row mb-3 border-bottom">
+                                                    <div class="col-md-2 text-center align-content-center text-bg-success">
+                                                        목표 설정
+                                                    </div>
+                                                    <div class="col-md-3">
+                                                        6명
+                                                    </div>
+                                                </div>
+                                                <div class="row mb-3 border-bottom">
+                                                    <div class="col-md-2 text-center align-content-center text-bg-success">
+                                                        완독
+                                                    </div>
+                                                    <div class="col-md-3">
+                                                        11명
+                                                    </div>
+                                                </div>
+                                                <div class="d-grid gap-2 d-md-flex justify-content-md-center">
+                                                    <button class="btn btn-success" type="button" id="addGoal">목표추가</button>
+                                                    <button class="btn btn-danger" type="button" id="addChallenge">도전하기</button>
+                                                </div>
+                                            </div>
+                                        </div>
+                                        <!-- END : Card blog with image -->
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+</div>
+</body>
+</html>


### PR DESCRIPTION
## #️⃣연관된 이슈

- #85

## 📝작업 내용

- 책 상세정보 페이지(memo/bookdetail)에서 '목표추가' 버튼을 누르면 readstate 테이블에 isbn13 / id / readstate('목표') 추가된다.

## 💬리뷰 요구사항(선택)

- 리뷰 요구사항 없음

## 📚참고자료 (선택)

- 참고자료 없음
