### PR TITLE
[feat] Stomp-Kafka 연동 #139

### DIFF
--- a/src/main/java/com/bunge/chat/config/WebSocketConfig.java
+++ b/src/main/java/com/bunge/chat/config/WebSocketConfig.java
@@ -18,7 +18,6 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
     @Override
     public void configureMessageBroker(MessageBrokerRegistry registry) {
-        registry.enableSimpleBroker("/sub");
         registry.setApplicationDestinationPrefixes("/pub");
     }
 }

--- a/src/main/java/com/bunge/chat/controller/ChatController.java
+++ b/src/main/java/com/bunge/chat/controller/ChatController.java
@@ -1,6 +1,5 @@
 package com.bunge.chat.controller;
 
-import com.bunge.chat.service.KafkaProducerService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -10,8 +9,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 @Controller
 @RequestMapping("/chat")
 public class ChatController {
-
-    private final KafkaProducerService producerService;
 
     @GetMapping
     public String chatPage() {

--- a/src/main/java/com/bunge/chat/controller/MessageController.java
+++ b/src/main/java/com/bunge/chat/controller/MessageController.java
@@ -1,7 +1,13 @@
 package com.bunge.chat.controller;
 
+import com.bunge.chat.KafkaTopic;
 import com.bunge.chat.domain.Message;
+import com.bunge.chat.service.KafkaConsumerService;
+import com.bunge.chat.service.KafkaProducerService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.SendTo;
 import org.springframework.messaging.simp.SimpMessageSendingOperations;
@@ -11,9 +17,16 @@ import org.springframework.stereotype.Controller;
 @RequiredArgsConstructor
 public class MessageController {
 
+    private final KafkaProducerService producerService;
+    private final KafkaConsumerService consumerService;
+
     @MessageMapping("/hello")
-    @SendTo("/sub/msg")
-    public String message(String message) {
-        return message;
+    public void publishMessage(String message) {
+        producerService.sendMessage(KafkaTopic.TEMP, message);
+    }
+
+    @KafkaListener(topics = KafkaTopic.TEMP, groupId = "kafka-consumer-group")
+    public void consumeMessage(String message, Acknowledgment ack) {
+        consumerService.handleMessage(KafkaTopic.TEMP, message, ack);
     }
 }

--- a/src/main/java/com/bunge/chat/service/KafkaConsumerService.java
+++ b/src/main/java/com/bunge/chat/service/KafkaConsumerService.java
@@ -1,18 +1,23 @@
 package com.bunge.chat.service;
 
 import com.bunge.chat.KafkaTopic;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
 
 @Slf4j
 @Service
+@RequiredArgsConstructor
 public class KafkaConsumerService {
 
-    @KafkaListener(topics = KafkaTopic.TEMP, groupId = "kafka-consumer-group")
-    public void handleMessage(String message, Acknowledgment ack) {
+    private final SimpMessagingTemplate template;
+
+    public void handleMessage(String topic, String message, Acknowledgment ack) {
         log.info("consumer message={}", message);
+        template.convertAndSend("/" + topic, message);
         ack.acknowledge();
     }
 }

--- a/src/main/resources/static/js/chat.js
+++ b/src/main/resources/static/js/chat.js
@@ -3,15 +3,17 @@ var stompClient = null;
 function connect() {
     var socket = new SockJS('/ws');
     stompClient = Stomp.over(socket);
-    stompClient.connect({}, function (frame) {
-        stompClient.subscribe('/sub/msg', function (greeting) {
-            console.log("받은 메세지" + greeting)
+    stompClient.debug = null
+    stompClient.connect({}, function () {
+        stompClient.subscribe('/topic-test', function (frame) {
+            console.log("받은 메세지" + frame)
         });
     });
 }
 
 function send() {
     stompClient.send("/pub/hello", {}, $(".chat-message-input").val());
+    console.log("보낸 메세지: " + $(".chat-message-input").val());
 }
 
 function handleEnterKey(e) {


### PR DESCRIPTION
## #️⃣연관된 이슈

- #139 

## 📝작업 내용

- Kafka에 Produce, Consume 처리하도록 MessageController 변경
- Stomp와 Kafka 발행/구독 경로 맵핑

## 💬리뷰 요구사항(선택)

- 리뷰 요구사항 없음

## 📚참고자료 (선택)

- https://wans1027.tistory.com/29
