### PR TITLE
[feat] 스터디 가입 신청 거절

### DIFF
--- a/src/main/java/com/bunge/study/controller/StudyController.java
+++ b/src/main/java/com/bunge/study/controller/StudyController.java
@@ -8,6 +8,7 @@ import com.bunge.study.filter.StudyBoardFilter;
 import com.bunge.study.domain.StudyBoard;
 import com.bunge.study.parameter.ApproveApplicationRequest;
 import com.bunge.study.parameter.BookSearchRequest;
+import com.bunge.study.parameter.RejectApplicationRequest;
 import com.bunge.study.service.StudyService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -203,6 +204,19 @@ public class StudyController {
             response.put("status", "error");
         }
 
+        return response;
+    }
+
+    @ResponseBody
+    @PostMapping("/reject-application")
+    public Map<String, Object> rejectApplication(@RequestBody RejectApplicationRequest rejectApplicationRequest) {
+        Map<String, Object> response = new HashMap<>();
+        try {
+            studyService.rejectApplication(rejectApplicationRequest);
+            response.put("status", "success");
+        } catch (Exception e) {
+            response.put("status", "error");
+        }
         return response;
     }
 

--- a/src/main/java/com/bunge/study/mapper/StudyMapper.java
+++ b/src/main/java/com/bunge/study/mapper/StudyMapper.java
@@ -8,6 +8,7 @@ import com.bunge.study.domain.StudyEvent;
 import com.bunge.study.filter.StudyBoardFilter;
 import com.bunge.study.parameter.ApproveApplicationRequest;
 import com.bunge.study.parameter.BookSearchRequest;
+import com.bunge.study.parameter.RejectApplicationRequest;
 import org.apache.ibatis.annotations.Insert;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Options;
@@ -61,4 +62,7 @@ public interface StudyMapper {
 
     //신청에 대한 승인 절차
     public void approveApplication(ApproveApplicationRequest approveApplicationRequest);
+
+    //신청에 대한 거절 절차
+    public void rejectApplication(RejectApplicationRequest rejectApplicationRequest);
 }

--- a/src/main/java/com/bunge/study/parameter/RejectApplicationRequest.java
+++ b/src/main/java/com/bunge/study/parameter/RejectApplicationRequest.java
@@ -1,0 +1,13 @@
+package com.bunge.study.parameter;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+@ToString
+@Setter
+@Getter
+public class RejectApplicationRequest {
+    private int no;
+    private String status;
+}

--- a/src/main/java/com/bunge/study/service/StudyService.java
+++ b/src/main/java/com/bunge/study/service/StudyService.java
@@ -8,6 +8,7 @@ import com.bunge.study.domain.StudyEvent;
 import com.bunge.study.filter.StudyBoardFilter;
 import com.bunge.study.parameter.ApproveApplicationRequest;
 import com.bunge.study.parameter.BookSearchRequest;
+import com.bunge.study.parameter.RejectApplicationRequest;
 
 import java.time.LocalDate;
 import java.util.Date;
@@ -60,5 +61,8 @@ public interface StudyService {
 
     //신청에 대한 승인 절차
     public void approveApplication(ApproveApplicationRequest approveApplicationRequest);
+
+    //신청에 대한 거절 절차
+    public void rejectApplication(RejectApplicationRequest rejectApplicationRequest);
 
 }

--- a/src/main/java/com/bunge/study/service/StudyServiceImpl.java
+++ b/src/main/java/com/bunge/study/service/StudyServiceImpl.java
@@ -9,6 +9,7 @@ import com.bunge.study.filter.StudyBoardFilter;
 import com.bunge.study.mapper.StudyMapper;
 import com.bunge.study.parameter.ApproveApplicationRequest;
 import com.bunge.study.parameter.BookSearchRequest;
+import com.bunge.study.parameter.RejectApplicationRequest;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -112,5 +113,10 @@ public class StudyServiceImpl implements StudyService {
     @Override
     public void approveApplication(ApproveApplicationRequest approveApplicationRequest) {
         studyMapper.approveApplication(approveApplicationRequest);
+    }
+
+    @Override
+    public void rejectApplication(RejectApplicationRequest rejectApplicationRequest) {
+        studyMapper.rejectApplication(rejectApplicationRequest);
     }
 }

--- a/src/main/resources/mapper/Study.xml
+++ b/src/main/resources/mapper/Study.xml
@@ -129,4 +129,10 @@
         where no = #{no}
     </update>
 
+    <update id="rejectApplication" parameterType="com.bunge.study.parameter.RejectApplicationRequest">
+        update studyapplication
+        set status = #{status}
+        where no = #{no}
+    </update>
+
 </mapper>

--- a/src/main/resources/static/js/studydetail.js
+++ b/src/main/resources/static/js/studydetail.js
@@ -182,6 +182,8 @@ $(function () {
                     let actionsTd = document.createElement("td");
                     if (application.status === "승인") {
                         actionsTd.innerHTML = `<button class="btn btn-link btn-sm" onclick="cancelApplication(${application.no})">승인취소</button>`;
+                    } else if (application.status === "거절") {
+                        actionsTd.innerHTML = `<button class="btn btn-link btn-sm" onclick="cancelReject(${application.no})">거절취소</button>`;
                     } else {
                         actionsTd.innerHTML = `<button class="btn btn-primary rounded-pill btn-xs" onclick="approveApplication(${application.no})">승인</button>
                                                &nbsp;<button class="btn btn-danger rounded-pill btn-xs" onclick="rejectApplication(${application.no})">거절</button>`;
@@ -222,6 +224,33 @@ $(function () {
                 alert("승인 중 오류가 발생했습니다. 다시 시도해주세요");
             });
     };
+
+    window.rejectApplication = function (applicationNo) {
+        fetch(`/study/reject-application`, {
+            method: "post",
+            headers: {
+                'Content-Type': 'application/json',
+                'X-CSRF-TOKEN': token
+            },
+            body: JSON.stringify({ no: applicationNo, status: "거절"})
+        })
+            .then(response => response.json())
+            .then(data => {
+                if (data.status === "success") {
+                    alert("승인이 거절 되었습니다")
+                    let applicationRow = $(`button[onclick="rejectApplication(${applicationNo})"]`).closest('tr');
+                    applicationRow.find('.status-area').html('<button class="btn btn-link btn-sm" onclick="cancelReject(${application.no})">거절취소</button>');
+                } else {
+                    alert("승인 거절 실패. 다시 시도해주세요")
+                }
+            })
+            .catch(error => {
+                console.log("Error:", error);
+                alert("거절 중 오류가 발생했습니다. 다시 시도해주세요");
+            });
+    };
+
+
 
 }) //ready end
 


### PR DESCRIPTION
## #️⃣연관된 이슈

- #225 

## 📝작업 내용

- 스터디 세부정보 화면에서 스터디 승인 버튼을 누르면 신청 리스트 관련 모달창 생성
- 모달창 리스트에서 거절 버튼을 누를 수 있음
- 거절 버튼을 눌러 성공하면 studyapplication 테이블 status 컬럼 값이 "거절"로 update됨
- 거절 버튼을 누르면 거절취소 버튼이 활성화됨

## 💬리뷰 요구사항(선택)

- 리뷰 요구사항 없음

## 📚참고자료 (선택)

- 참고자료 없음