### PR TITLE
[채팅] 메세지 없을 때 채팅 못 불러오는 에러 수정

### DIFF
--- a/src/main/resources/mapper/Chat.xml
+++ b/src/main/resources/mapper/Chat.xml
@@ -14,29 +14,37 @@
     </insert>
 
     <select id="findAllByMemberId" parameterType="String" resultType="ChatListDto">
-        WITH latest_messages AS (SELECT m1.chatroom_id, m1.type, m1.data, m1.create_date
-                                 FROM message m1
-                                          JOIN (SELECT chatroom_id, MAX(create_date) AS max_create_date
-                                                FROM message
-                                                GROUP BY chatroom_id) m2
-                                               ON m1.chatroom_id = m2.chatroom_id AND m1.create_date = m2.max_create_date)
+        WITH latest_messages AS (
+            SELECT m1.chatroom_id, m1.type, m1.data, m1.create_date
+            FROM message m1
+                     JOIN (
+                SELECT chatroom_id, MAX(create_date) AS max_create_date
+                FROM message
+                GROUP BY chatroom_id
+            ) m2 ON m1.chatroom_id = m2.chatroom_id AND m1.create_date = m2.max_create_date
+        )
 
-        SELECT chatroom.id         AS chatroom_id,
-               member.nick         AS nick,
-               chatroom.state      AS state,
-               message.type        AS type,
-               message.data        AS data,
-               message.create_date AS create_date
-        FROM chatroom
-                 JOIN
-             chat_relation ON chatroom.id = chat_relation.chatroom_id
-                 JOIN
-             member ON member.id = chat_relation.member_id
-                 JOIN
-             latest_messages message ON chatroom.id = message.chatroom_id
-        WHERE chatroom.id IN (SELECT chatroom_id
-                              FROM chat_relation
-                              WHERE member_id = #{loginMemberId})
+        SELECT
+            chatroom.id AS chatroomID,
+            member.nick AS nick,
+            chatroom.state AS state,
+            COALESCE(message.type, '') AS type,
+            COALESCE(message.data, '') AS data,
+            COALESCE(message.create_date, chatroom.create_date) AS create_date
+        FROM
+            chatroom
+                JOIN
+            chat_relation ON chatroom.id = chat_relation.chatroom_id
+                JOIN
+            member ON member.id = chat_relation.member_id
+                LEFT JOIN
+            latest_messages message ON chatroom.id = message.chatroom_id
+        WHERE
+            chatroom.id IN (
+                SELECT chatroom_id
+                FROM chat_relation
+                WHERE member_id = #{loginMemberId}
+            )
           AND member_id != #{loginMemberId};
     </select>
 


### PR DESCRIPTION
## #️⃣연관된 이슈

- 관된 이슈 없음

## 📝작업 내용

- 메세지 없을 때 채팅 못 불러오는 에러 수정(쿼리)

## 💬리뷰 요구사항(선택)

- 리뷰 요구사항 없음

## 📚참고자료 (선택)

- 참고자료 없음
