### PR TITLE
[fix] 스터디룸에서 레이아웃 배치 변경

### DIFF
--- a/src/main/resources/templates/study/study_mine.html
+++ b/src/main/resources/templates/study/study_mine.html
@@ -582,157 +582,102 @@
                 </div>
               </div>
             </div>
-
-            <!--            공지 사항           -->
-            <div class="mb-3">
-              <div class="card">
-                <div class="card-body">
-                  <div>
-                    <div class="mb-2 d-flex justify-content-between align-items-center">
-                      <h3 class="h4 card-title align-self-start"><i class="pli-speaker-2"></i>&nbsp; 공지사항</h3>
-                      <button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#noticeModal">
-                        공지사항 추가
-                      </button>
-                    </div>
-                  </div><hr>
-
-                  <!-- 공지사항 등록 모달 -->
-                  <div class="modal col-md-6 mb-3" id="noticeModal">
-                    <div class="modal-dialog">
-                      <div class="modal-content">
-                        <div class="modal-header">
-                          <h5 class="modal-title">공지사항 추가</h5>
-                        </div>
-
-                        <div class="modal-body">
-                          <form id="addNoticeForm">
-                            <div class="mb-3">
-                              <label for="noticeLeaderId" class="form-label">작성자</label>
-                              <input type="text" class="form-control" id="noticeLeaderId" readonly>
-                            </div>
-
-                            <div class="mb-3">
-                              <label for="noticeTitle" class="form-label">제목</label>
-                              <input type="text" class="form-control" id="noticeTitle" required>
-                            </div>
-
-                            <div class="col-sm-12">
-                              <textarea id="noticeContent" class="form-control" placeholder="Message" rows="14" maxlength="500" style="resize: none;"></textarea>
-                              <p class="float-end"><span id="charCount">0</span>/500</p>
-                            </div><br>
-
-                            <div class="d-flex justify-content-center">
-                              <button type="button" class="btn btn-primary" id="addButton">등록</button>
-                              <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">취소</button>
-                            </div>
-
-                          </form>
-                        </div>
-                        <!-- 공지사항 등록 모달 -->
-
-
-                      </div>
-                    </div>
-                  </div>
-
-                  <!-- GridJS - Resizable columns -->
-                  <div id="noticesList" role="complementary" class="gridjs gridjs-container" style="width: 100%;">
-                    <div class="gridjs-wrapper" style="height: 275px;">
-
-                      <div class="mb-2">
-                        &nbsp;&nbsp;<table class="table">
-
-
-                        <thead>
-
-                        <tr>
-                          <th style="min-width:80px; width:80px">번호</th>
-                          <th style="min-width:200px; width:200px">제목</th>
-                          <th style="min-width:100px; width:100px">작성자</th>
-                          <th style="min-width:100px; width:100px">작성일</th>
-                        </tr>
-
-                        <thead>
-                        <tbody id="noticeTable">
-                        <tr>
-                          <th></th>
-                          <th></th>
-                          <th></th>
-                          <th></th>
-                        </tr>
-                        </tbody>
-                      </table>
-                      </div>
-                    </div>
-                    <div id="gridjs-temp" class="gridjs-temp"></div>
-
-                  </div>
-                </div>
-                <!-- END : GridJS - Resizable columns -->
-
-              </div>
-            </div>
-            <!--          공지사항         -->
-
           </div>
-
         </div>
 
 
         <div class="col-md-6">
-          <div class="tab-base">
 
-            <!-- Nav tabs -->
-            <ul class="nav nav-tabs" role="tablist">
-              <li class="nav-item active" role="presentation">
-                <button class="nav-link active" data-bs-toggle="tab" data-bs-target="#_dm-tabsFeed" type="button" role="tab" aria-controls="summary" aria-selected="true" tabindex="-1">담벼락</button>
-              </li>
-            </ul>
+          <!--            공지 사항           -->
+          <div class="mb-3">
+            <div class="card">
+              <div class="card-body">
+                <div>
+                  <div class="mb-2 d-flex justify-content-between align-items-center">
+                    <h3 class="h4 card-title align-self-start"><i class="pli-speaker-2"></i>&nbsp; 공지사항</h3>
+                    <button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#noticeModal">
+                      공지사항 추가
+                    </button>
+                  </div>
+                </div><hr>
 
-            <!-- Tabs content -->
-            <div class="tab-content mb-3">
+                <!-- 공지사항 등록 모달 -->
+                <div class="modal col-md-6 mb-3" id="noticeModal">
+                  <div class="modal-dialog">
+                    <div class="modal-content">
+                      <div class="modal-header">
+                        <h5 class="modal-title">공지사항 추가</h5>
+                      </div>
 
-              <div id="_dm-tabsFeed" class="tab-pane fade active show" role="tabpanel" aria-labelledby="profile-tab">
-                <div class="mb-2">
-                  <button type="button" class="btn btn-primary rounded-pill">담벼락 글 추가</button>
-                </div>
-                <div class="mb-2">
-                  &nbsp;&nbsp;&nbsp;&nbsp;<img class="img-xs rounded-circle" th:src="@{/img/profile-photos/7.png}" alt="Profile Picture" loading="lazy"><a href="#">"고라니 (24.05.15)" 님에 대한 강퇴 투표가 시작되었습니다. 과반 이상 찬성 시 승인 절차 진행합니다.</a>
+                      <div class="modal-body">
+                        <form id="addNoticeForm">
+                          <div class="mb-3">
+                            <label for="noticeLeaderId" class="form-label">작성자</label>
+                            <input type="text" class="form-control" id="noticeLeaderId" readonly>
+                          </div>
+
+                          <div class="mb-3">
+                            <label for="noticeTitle" class="form-label">제목</label>
+                            <input type="text" class="form-control" id="noticeTitle" required>
+                          </div>
+
+                          <div class="col-sm-12">
+                            <textarea id="noticeContent" class="form-control" placeholder="Message" rows="14" maxlength="500" style="resize: none;"></textarea>
+                            <p class="float-end"><span id="charCount">0</span>/500</p>
+                          </div><br>
+
+                          <div class="d-flex justify-content-center">
+                            <button type="button" class="btn btn-primary" id="addButton">등록</button>
+                            <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">취소</button>
+                          </div>
+
+                        </form>
+                      </div>
+                      <!-- 공지사항 등록 모달 -->
+
+
+                    </div>
+                  </div>
                 </div>
 
-                <div class="mb-2">
-                  &nbsp;&nbsp;&nbsp;&nbsp;<img class="img-xs rounded-circle" th:src="@{/img/profile-photos/8.png}" alt="Profile Picture" loading="lazy">김레오 (24.05.15) 과제 제출 신속히 부탁
-                </div>
+                <!-- GridJS - Resizable columns -->
+                <div id="noticesList" role="complementary" class="gridjs gridjs-container" style="width: 100%;">
+                  <div class="gridjs-wrapper" style="height: 275px;">
 
-                <div class="mb-2">
-                  &nbsp;&nbsp;&nbsp;&nbsp;<img class="img-xs rounded-circle" th:src="@{/img/profile-photos/8.png}" alt="Profile Picture" loading="lazy">박칼린 (24.05.14) 이번에 스터디 어디서 해요??
-                </div>
+                    <div class="mb-2">
+                      &nbsp;&nbsp;<table class="table">
 
-                <div class="mb-2">
-                  &nbsp;&nbsp;&nbsp;&nbsp;<img class="img-xs rounded-circle" th:src="@{/img/profile-photos/8.png}" alt="Profile Picture" loading="lazy"><a href="#">"목표도서 변경" 안건에 대한 승인 절차가 진행 중입니다.</a>
-                </div>
 
-                <div class="mb-2">
-                  &nbsp;&nbsp;&nbsp;&nbsp;<img class="img-xs rounded-circle" th:src="@{/img/profile-photos/8.png}" alt="Profile Picture" loading="lazy">고라니 (24.05.13) 탈퇴 / 강퇴 / 신고기능 있나요??
-                </div>
+                      <thead>
 
-                <div class="mb-2">
-                  &nbsp;&nbsp;&nbsp;&nbsp;<img class="img-xs rounded-circle" th:src="@{/img/profile-photos/8.png}" alt="Profile Picture" loading="lazy">고라니 (24.05.13) 리더가 관리할 수 있는 기능 있나요??
-                </div>
-                <div class="mb-2">
-                  &nbsp;&nbsp;&nbsp;&nbsp;<img class="img-xs rounded-circle" th:src="@{/img/profile-photos/8.png}" alt="Profile Picture" loading="lazy">고라니 (24.05.12) 리더가 관리할 수 있는 기능 있나요??
-                </div>
-                <div class="mb-2">
-                  &nbsp;&nbsp;&nbsp;&nbsp;<img class="img-xs rounded-circle" th:src="@{/img/profile-photos/8.png}" alt="Profile Picture" loading="lazy"><a href="#">"도전기간 변경" 안건에 대한 승인 절차가 진행 중입니다.</a>
-                </div>
-                <div class="mb-2">
-                  &nbsp;&nbsp;&nbsp;&nbsp;<img class="img-xs rounded-circle" th:src="@{/img/profile-photos/8.png}" alt="Profile Picture" loading="lazy">고라니 (24.05.11) 리더가 관리할 수 있는 기능 있나요??
-                </div>
-                <div class="mb-2">
-                  &nbsp;&nbsp;&nbsp;&nbsp;<img class="img-xs rounded-circle" th:src="@{/img/profile-photos/8.png}" alt="Profile Picture" loading="lazy">고라니 (24.05.10) 리더가 관리할 수 있는 기능 있나요??
+                      <tr>
+                        <th style="min-width:80px; width:80px">번호</th>
+                        <th style="min-width:200px; width:200px">제목</th>
+                        <th style="min-width:100px; width:100px">작성자</th>
+                        <th style="min-width:100px; width:100px">작성일</th>
+                      </tr>
+
+                      <thead>
+                      <tbody id="noticeTable">
+                      <tr>
+                        <th></th>
+                        <th></th>
+                        <th></th>
+                        <th></th>
+                      </tr>
+                      </tbody>
+                    </table>
+                    </div>
+                  </div>
+                  <div id="gridjs-temp" class="gridjs-temp"></div>
+
                 </div>
               </div>
+              <!-- END : GridJS - Resizable columns -->
+
             </div>
+          </div>
+          <!--          공지사항         -->
 
             <div class="card">
               <div class="card-body">


### PR DESCRIPTION
## #️⃣연관된 이슈

- 연관된 이슈 없음

## 📝작업 내용

- 담벼락 영역 삭제, 파일 공유하기 부분 분리, 공지사항 부분 오른쪽 상단으로 이동하여 담벼락 부분에 배치

## 💬리뷰 요구사항(선택)

- 리뷰 요구사항 없음

## 📚참고자료 (선택)

- 참고자료 없음