### PR TITLE
[fix] 가장 최근 채팅 중복 문제 해결

### DIFF
--- a/src/main/resources/mapper/Chat.xml
+++ b/src/main/resources/mapper/Chat.xml
@@ -15,17 +15,17 @@
 
     <select id="findAllByMemberId" parameterType="String" resultType="ChatListDto">
         WITH latest_messages AS (
-            SELECT m1.chatroom_id, m1.type, m1.data, m1.create_date
+            SELECT m1.chatroom_id, m1.type, m1.data, m1.create_date, m1.id
             FROM message m1
                      JOIN (
-                SELECT chatroom_id, MAX(create_date) AS max_create_date
+                SELECT chatroom_id, MAX(id) AS max_message_id
                 FROM message
                 GROUP BY chatroom_id
-            ) m2 ON m1.chatroom_id = m2.chatroom_id AND m1.create_date = m2.max_create_date
+            ) m2 ON m1.chatroom_id = m2.chatroom_id AND m1.id = m2.max_message_id
         )
 
         SELECT
-            chatroom.id AS chatroomID,
+            chatroom.id AS chatroomId,
             member.nick AS nick,
             chatroom.state AS state,
             COALESCE(message.type, '') AS type,


### PR DESCRIPTION
## #️⃣연관된 이슈

- 연관된 이슈 없음

## 📝작업 내용

- 쿼리 문제로 가장 최근 채팅이 중복으로 조회되는 문제 해결

## 💬리뷰 요구사항(선택)

- 리뷰 요구사항 없음

## 📚참고자료 (선택)

- 참고자료 없음
