### PR TITLE
[refactor] 스터디 메인페이지 상태 정보 refactoring

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -12,17 +12,17 @@ spring:
   ##db connection(MySQL)
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
-    url:
-    username:
-    password:
-    Database:
+    url: jdbc:mysql://database-2.czg0im8cs8fs.ap-northeast-2.rds.amazonaws.com:3306/bunge?characterEncoding=utf8
+    username: bunge
+    password: bunge2308
+    Database : bunge
 
   #mail
   mail:
     host: smtp.naver.com
     port: 587
-    username:
-    password:
+    username: gksrmf2008@naver.com
+    password: as124578*
     properties:
       mail.smtp.auth: true
 
@@ -32,7 +32,7 @@ spring:
 
 #my:
 #  savefolder: c:\img\profile-photos
-#  savepath: file:///C:/img/profile-photos/
+# savepath: file:///C:/img/profile-photos/
 
 #aws
 my:
@@ -56,6 +56,5 @@ logging:
   level:
     com.bunge.member.mapper.MemberMapper: TRACE
     com.bunge.inquiry.mapper.InquiryMapper: TRACE
-
 server:
   port: 8090

--- a/src/main/resources/mapper/Study.xml
+++ b/src/main/resources/mapper/Study.xml
@@ -39,7 +39,7 @@
             and s.id like CONCAT('%', #{keyword}, '%')
         </if>
         group by s.no
-        order by s.state, s.no desc
+        order by s.state, s.challengeend desc, s.no desc
         limit #{offset}, #{limit}
     </select>
 

--- a/src/main/resources/templates/study/study_main.html
+++ b/src/main/resources/templates/study/study_main.html
@@ -100,8 +100,8 @@
                                         <a class="btn-link text-nowrap">[[${list.id}]]</a>
                                     </td>
                                     <td th:id="${#strings.append('status-', list.no)}" class="h5">
-                                        <div th:if="${list.state == 0}" class="d-block badge bg-success">모집중</div>
-                                        <div th:if="${list.state == 1}" class="d-block badge bg-danger">마감</div>
+                                        <div th:if="${list.state == 0 and list.studystatus == null}" class="d-block badge bg-success">모집중</div>
+                                        <div th:if="${list.state == 1 and list.studystatus == null}" class="d-block badge bg-danger">마감</div>
                                         <div th:if="${list.studystatus == 'progress'}" class="d-block badge bg-info">진행중</div>
                                         <div th:if="${list.studystatus == 'end'}" class="d-block badge bg-secondary">종료</div>
                                         <div th:if="${#strings.equals(list.id, loginId)} and ${list.pendingcount > 0}" class="d-block badge bg-warning">승인대기[[${list.pendingcount}]]</div>


### PR DESCRIPTION
## #️⃣연관된 이슈

- 연관된 이슈 없음

## 📝작업 내용

- 스터디 메인페이지에서 (1)모집중 / 마감 (2)진행중 / 종료 등 상태 관련 정보를 표시하는 방법 번경
- 스터디 메인페이지 배치 순서 변경 (모집중 > 마감 > 진행중 > 종료 순서로 정렬, 같은 계층에서는 no 값을 기준으로 정렬)

## 💬리뷰 요구사항(선택)

- 리뷰 요구사항 없음

## 📚참고자료 (선택)

- 참고자료 없음